### PR TITLE
[SSD] Refactoring : SSDDevice에 강제로 ssd_output.txt에 ERROR를 표시하기 위해 pri…

### DIFF
--- a/SSD/SSDDevice.cpp
+++ b/SSD/SSDDevice.cpp
@@ -28,6 +28,11 @@ int SSDDevice::readData(const int lba) {
     return data;
 }
 
+void SSDDevice::printError(void) {
+    SSDFileOutput fLog;
+    fLog.logError();
+}
+
 void SSDDevice::writeData(const int lba, const int data) {
     if (isLbaOutOfRange(lba)) throw std::invalid_argument("Out of LBA Range.");
     fSsd.writeData(lba, data);

--- a/SSD/SSDDevice.h
+++ b/SSD/SSDDevice.h
@@ -9,6 +9,7 @@ public:
     int readData(const int lba);
     void writeData(const int lba, const int data);
     void reinitializeFile(void);
+    void printError(void);
 
 private:
     void initializeCellData(void);

--- a/SSD/SSDDevice_test.cpp
+++ b/SSD/SSDDevice_test.cpp
@@ -183,3 +183,15 @@ TEST_F(SSDDeviceFixture, ssdReadDataTC4FileOutputCheckError) {
         EXPECT_TRUE(containsError());
     }
 }
+
+TEST_F(SSDDeviceFixture, ssdReadDataTC4FileOutputCheckForcedError) {
+    for (LBA_DATA lba_data : inRangeLbaDatas) {
+        ssd.writeData(lba_data.lba, lba_data.data);
+        int actual = ssd.readData(lba_data.lba);
+        EXPECT_EQ(lba_data.data, actual);
+        EXPECT_TRUE(containsValue(actual));
+
+        ssd.printError();
+        EXPECT_TRUE(containsError());
+    }
+}

--- a/SSD/SSDFileStorageDevice.h
+++ b/SSD/SSDFileStorageDevice.h
@@ -32,5 +32,5 @@ private:
     int maxMapCapacity;
     int upperLbaLimit;
     int lowerLbaLimit = 0;
-    const int TOUCHED_FLAG = 1;
+    static const int TOUCHED_FLAG = 1;
 };


### PR DESCRIPTION
## Pull Request 작업 개요
- SSDDevice에 강제로 ssd_output.txt에 ERROR를 표시하기 위해 printError() 메서드 추가.

## PR Requester 체크리스트 (모두 체크 후 PR)
- [x] PR 제목과 설명을 명확하게 작성
- [x] 변경 범위가 너무 크지 않도록 분리
- [x] 코드가 정상적으로 동작하는가?
- [x] 테스트 코드가 존재하는가?
- [] 리팩토링이 포함되었는가?

## 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경

## 작업 상세 내용
1. [SSD] Refactoring : SSDDevice에 강제로 ssd_output.txt에 ERROR를 표시하기 위해 printError() 메서드 추가.

## 생각해볼 문제
1. 

### 코드리뷰시 리뷰어 체크리스트
---
1. 상세 리뷰 시 코드 위치에 달기
2. 리뷰와 함께 아이디어 제안하기
3. 각 유닛(unit)이 하나의 단일 기능(function)을 구현하는가?
4. 분할되었어야 하는 유닛이 있는가?
5. 코드가 상세 설계(detailed design)와 일관적인가?
6. 모든 변수가 정의되고(defined) 초기화되는가(initiated)? 
7. 정확한 타입(types)과 범위(scopes)인지 체크되었는가?모든 변수가 사용되는가?
8. 오버플로우 또는 언더플로우 가능성이 있는가(예, 0으로 나누기)?
9. 비교 오퍼레이터(the comparison operators)가 정확한가?
10. 모든 파일이 사용을 위해 열렸는가? 종료 시 모든 파일이 적절하게 닫히는가?
11. const를 적절히 사용하고 있는가?
