### PR TITLE
[TestShell] Shell Exit 시 SSD NAND 를 지워서 다음 Test에 영향이 없도록 Erase All 

### DIFF
--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -276,6 +276,9 @@ bool Shell::eraseRangeApi(void) {
 
 bool Shell::exitApi(void) {
 	if (isValidParameterSize(EXIT_PARAMETER_SIZE)) {
+
+		fulleraseApi();
+
 		return true;
 	}
 	return false;
@@ -336,6 +339,14 @@ bool Shell::fullreadApi(void) {
 		return true;
 	}
 	return false;
+}
+
+void Shell::fulleraseApi(void) {
+	for (auto lba = 0; lba < MAX_SIZE; )
+	{
+		m_ISSDAdapter->erase(lba, CHUNK_SIZE);
+		lba += CHUNK_SIZE;
+	}
 }
 
 bool Shell::isValidParameterSize(const int size) {

--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -342,10 +342,9 @@ bool Shell::fullreadApi(void) {
 }
 
 void Shell::fulleraseApi(void) {
-	for (auto lba = 0; lba < MAX_SIZE; )
+	for (auto lba = 0; lba < MAX_SIZE; lba += CHUNK_SIZE)
 	{
 		m_ISSDAdapter->erase(lba, CHUNK_SIZE);
-		lba += CHUNK_SIZE;
 	}
 }
 

--- a/TestShell/shell.h
+++ b/TestShell/shell.h
@@ -27,6 +27,7 @@ public:
 	const int CHUNK_SIZE = 10;
 
 	Shell(ISSDAdapter* ISSDAdapter);
+
 	void executeShell(void);
 	void setCommand(std::string command);
 
@@ -54,6 +55,7 @@ private:
 	bool flushApi(void);
 	bool fullwriteApi(void);
 	bool fullreadApi(void);
+	void fulleraseApi(void);
 	bool isValidParameterSize(const int size);
 	bool isValidLBA(const int pos);
 	bool isValidData(const int pos);


### PR DESCRIPTION
## Pull Request 작업 개요
- [TestShell] Shell Exit 시 SSD NAND 를 지워서 다음 Test에 영향이 없도록 Erase All 

## PR Requester 체크리스트 (모두 체크 후 PR)
- [x] PR 제목과 설명을 명확하게 작성
- [x] 변경 범위가 너무 크지 않도록 분리
- [x] 코드가 정상적으로 동작하는가?
- [x] 테스트 코드가 존재하는가?
- [] 리팩토링이 포함되었는가?

## 작업 분류
- [x] 신규 기능
- [x] 버그 수정
- [ ] 프로젝트 구조 변경

## 작업 상세 내용
1. Shell 수행 시 마다 이전 NAND 상태가 남아 있어 테스트시 오류가 나서 이를 해결
2. Shell Exit 할때마다 NAND를 모두 지우도록 함

## 생각해볼 문제
1. 

### 코드리뷰시 리뷰어 체크리스트
---
1. 상세 리뷰 시 코드 위치에 달기
3. 리뷰와 함께 아이디어 제안하기
4. 각 유닛(unit)이 하나의 단일 기능(function)을 구현하는가?
5. 분할되었어야 하는 유닛이 있는가?
6. 코드가 상세 설계(detailed design)와 일관적인가?
7. 모든 변수가 정의되고(defined) 초기화되는가(initiated)? 
8. 정확한 타입(types)과 범위(scopes)인지 체크되었는가?모든 변수가 사용되는가?
9. 오버플로우 또는 언더플로우 가능성이 있는가(예, 0으로 나누기)?
10. 비교 오퍼레이터(the comparison operators)가 정확한가?
11. 모든 파일이 사용을 위해 열렸는가? 종료 시 모든 파일이 적절하게 닫히는가?
12. const를 적절히 사용하고 있는가?
